### PR TITLE
DRA: fail getting CDI annotations if resource is not found

### DIFF
--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -667,7 +667,11 @@ func (cm *containerManagerImpl) GetResources(pod *v1.Pod, container *v1.Containe
 	// Set container annotations from the CDI reconciler to
 	// trigger CDI injection
 	if cm.draManager != nil {
-		opts.Annotations = append(opts.Annotations, cm.draManager.GetCDIAnnotations(pod, container)...)
+		annotations, err := cm.draManager.GetCDIAnnotations(pod, container)
+		if err != nil {
+			return nil, err
+		}
+		opts.Annotations = append(opts.Annotations, annotations...)
 	}
 	// Allocate should already be called during predicateAdmitHandler.Admit(),
 	// just try to fetch device runtime information from cached state here

--- a/pkg/kubelet/cm/dra/manager.go
+++ b/pkg/kubelet/cm/dra/manager.go
@@ -257,18 +257,17 @@ func (m *ManagerImpl) UpdatePodResources() {
 	m.podResources.delete(podsToBeRemoved.List())
 }
 
-func (m *ManagerImpl) GetCDIAnnotations(pod *v1.Pod, container *v1.Container) []kubecontainer.Annotation {
+func (m *ManagerImpl) GetCDIAnnotations(pod *v1.Pod, container *v1.Container) ([]kubecontainer.Annotation, error) {
 	annotations := []kubecontainer.Annotation{}
 	for _, claim := range container.Resources.Claims {
 		resource := m.podResources.get(pod.UID, container.Name, claim)
 		if resource == nil {
-			klog.V(3).Infof("unable to get resource for pod: %s, container: %s, claim: %s, pod resources: %+v", pod.Name, container.Name, claim, m.podResources)
-			continue
+			return nil, fmt.Errorf(fmt.Sprintf("unable to get resource for pod: %s, container: %s, claim: %s", pod.Name, container.Name, claim))
 		}
 		klog.V(3).Infof("GetCDIAnnotations: claim %s: add resource annotations: %+v", resource.annotations)
 		annotations = append(annotations, resource.annotations...)
 	}
-	return annotations
+	return annotations, nil
 }
 
 func (m *ManagerImpl) UnprepareResources(pod *v1.Pod) error {

--- a/pkg/kubelet/cm/dra/types.go
+++ b/pkg/kubelet/cm/dra/types.go
@@ -46,7 +46,7 @@ type Manager interface {
 	// GetCDIAnnotations checks whether we have cached resource
 	// for the passed-in <pod, container> and returns its container annotations or
 	// empty map if resource is not cached
-	GetCDIAnnotations(pod *v1.Pod, container *v1.Container) []kubecontainer.Annotation
+	GetCDIAnnotations(pod *v1.Pod, container *v1.Container) ([]kubecontainer.Annotation, error)
 
 	// UnprepareResources calls NodeUnprepareResource GRPC from DRA plugin to unprepare pod resources
 	UnprepareResources(pod *v1.Pod) error


### PR DESCRIPTION
If resource is not found in the DRA manager cache Kubelet should not run a container. This should be considered as fatal error because CDI injection can't happen without this.