### PR TITLE
e2e dra: add support for containerd from main in kind

### DIFF
--- a/test/e2e/dra/README.md
+++ b/test/e2e/dra/README.md
@@ -1,3 +1,5 @@
+# Overview
+
 The tests in this directory cover dynamic resource allocation support in
 Kubernetes. They do not test the correct behavior of arbitrary dynamic resource
 allocation drivers.
@@ -10,3 +12,12 @@ done for CSI mock testing. The advantage is that no separate images are needed
 for the test driver and that the e2e test has full control over all gRPC calls,
 in case that it needs that for operations like error injection or checking
 calls.
+
+# Cluster setup
+
+The container runtime must support CDI. The latest cri-o releases contain
+support, containerd 1.6.x does not. To bring up a kind cluster with containerd
+built from their main branch, use:
+
+    test/e2e/dra/kind-build-image.sh dra/node:latest && \
+    kind create cluster --config test/e2e/dra/kind.yaml --image dra/node:latest

--- a/test/e2e/dra/dra.go
+++ b/test/e2e/dra/dra.go
@@ -68,7 +68,7 @@ var _ = ginkgo.Describe("[sig-node] DRA [Feature:DynamicResourceAllocation]", fu
 		// This test does not pass at the moment because kubelet doesn't retry.
 		ginkgo.It("must retry NodePrepareResource", func() {
 			// We have exactly one host.
-			m := MethodInstance{driver.Hostnames()[0], NodePrepareResourceMethod}
+			m := MethodInstance{driver.Nodenames()[0], NodePrepareResourceMethod}
 
 			driver.Fail(m, true)
 
@@ -484,7 +484,7 @@ func (b *builder) nodeSelector() *v1.NodeSelector {
 					{
 						Key:      "kubernetes.io/hostname",
 						Operator: v1.NodeSelectorOpIn,
-						Values:   b.driver.Hostnames(),
+						Values:   b.driver.Nodenames(),
 					},
 				},
 			},
@@ -736,7 +736,7 @@ func (b *builder) tearDown() {
 		}
 	}
 
-	for host, plugin := range b.driver.Hosts {
+	for host, plugin := range b.driver.Nodes {
 		ginkgo.By(fmt.Sprintf("waiting for resources on %s to be unprepared", host))
 		gomega.Eventually(plugin.GetPreparedResources).WithTimeout(time.Minute).Should(gomega.BeEmpty(), "prepared claims on host %s", host)
 	}

--- a/test/e2e/dra/kind-build-image.sh
+++ b/test/e2e/dra/kind-build-image.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This scripts invokes `kind build image` so that the resulting
+# image has a containerd with CDI support.
+#
+# Usage: kind-build-image.sh <tag of generated image>
+
+set -ex
+set -o pipefail
+
+tag="$1"
+containerd=containerd-1.6.0-830-g34d078e99 # from https://github.com/kind-ci/containerd-nightlies/releases
+
+tmpdir="$(mktemp -d)"
+cleanup() {
+    rm -rf "$tmpdir"
+}
+trap cleanup EXIT
+
+kind build node-image --image "$tag"
+curl -L --silent https://github.com/kind-ci/containerd-nightlies/releases/download/$containerd/$containerd-linux-amd64.tar.gz | tar -C "$tmpdir" -vzxf -
+curl -L --silent https://github.com/kind-ci/containerd-nightlies/releases/download/$containerd/runc.amd64 >"$tmpdir/runc"
+
+cat >"$tmpdir/Dockerfile" <<EOF
+FROM $tag
+
+COPY bin/* /usr/local/bin/
+RUN chmod a+rx /usr/local/bin/*
+COPY runc /usr/local/sbin
+RUN chmod a+rx /usr/local/sbin/runc
+
+# Enable CDI as described in https://github.com/container-orchestrated-devices/container-device-interface#containerd-configuration
+RUN sed -i -e '/\[plugins."io.containerd.grpc.v1.cri"\]/a \ \ enable_cdi = true' /etc/containerd/config.toml
+EOF
+
+docker build --tag "$tag" "$tmpdir"

--- a/test/e2e/dra/kind.yaml
+++ b/test/e2e/dra/kind.yaml
@@ -1,0 +1,17 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    scheduler:
+        extraArgs:
+          v: "5"
+    controllerManager:
+        extraArgs:
+          v: "5"
+- role: worker
+- role: worker
+featureGates:
+  DynamicResourceAllocation: true


### PR DESCRIPTION
These instructions bring up a kind cluster with containerd 34d078e99, the latest commit from the main branch. This version of containerd should have support for CDI, but in practice it didn't work.
