### PR TITLE
kubelet: check if claim is reserved for pod

### DIFF
--- a/pkg/kubelet/cm/dra/manager.go
+++ b/pkg/kubelet/cm/dra/manager.go
@@ -97,6 +97,11 @@ func (m *ManagerImpl) prepareContainerResources(pod *v1.Pod, container *v1.Conta
 				return fmt.Errorf("failed to fetch ResourceClaim %s referenced by pod %s: %+v", claimName, pod.Name, err)
 			}
 
+			// Check if pod is in the ReservedFor for the claim
+			if !resourceclaim.IsReservedForPod(pod, resourceClaim) {
+				return fmt.Errorf("pod %s(%s) is not allowed to use resource claim %s(%s)", pod.Name, pod.UID, podResourceClaim.Name, resourceClaim.UID)
+			}
+
 			// Call NodePrepareResource RPC
 			driverName := resourceClaim.Status.DriverName
 			client, err := dra.NewDRAPluginClient(driverName)


### PR DESCRIPTION
@pohly this is a simpler variant of #34
Unfortunately I couldn't find an easy way to implement e2e test for this because it would take a long time because of retries.
Checking if the Kubelet sent an event seems [not a good idea either](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/framework/events/events.go#L34)