### PR TITLE
Kubelet: DRA code cleanup

### DIFF
--- a/pkg/kubelet/cm/dra/manager.go
+++ b/pkg/kubelet/cm/dra/manager.go
@@ -56,21 +56,30 @@ func NewManagerImpl(kubeClient clientset.Interface) (*ManagerImpl, error) {
 	return manager, nil
 }
 
-// Generate container annotations using CDI UpdateAnnotations API
-func generateCDIAnnotation(claimUID types.UID, driverName string, cdiDevices []string) ([]kubecontainer.Annotation, error) {
+// Generate container annotations using CDI UpdateAnnotations API.
+func generateCDIAnnotation(
+	claimUID types.UID,
+	driverName string,
+	cdiDevices []string,
+) ([]kubecontainer.Annotation, error) {
 	const maxKeyLen = 63 // max length of the CDI annotation key
+
 	deviceID := string(claimUID)
+
 	if len(deviceID) > maxKeyLen-len(driverName)-1 {
 		deviceID = deviceID[:maxKeyLen-len(driverName)-1]
 	}
+
 	annotations, err := cdi.UpdateAnnotations(map[string]string{}, driverName, deviceID, cdiDevices)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("can't generate CDI annotations: %w", err)
 	}
+
 	kubeAnnotations := []kubecontainer.Annotation{}
 	for key, value := range annotations {
 		kubeAnnotations = append(kubeAnnotations, kubecontainer.Annotation{Name: key, Value: value})
 	}
+
 	return kubeAnnotations, nil
 }
 
@@ -88,36 +97,49 @@ func (m *ManagerImpl) prepareContainerResources(pod *v1.Pod, container *v1.Conta
 			if resource := m.resources.get(claimName, pod.Namespace); resource != nil {
 				// resource is already prepared, add pod UID to it
 				resource.addPodUID(pod.UID)
+
 				continue
 			}
 
 			// Query claim object from the API server
-			resourceClaim, err := m.kubeClient.CoreV1().ResourceClaims(pod.Namespace).Get(context.TODO(), claimName, metav1.GetOptions{})
+			resourceClaim, err := m.kubeClient.CoreV1().ResourceClaims(pod.Namespace).Get(
+				context.TODO(),
+				claimName,
+				metav1.GetOptions{})
 			if err != nil {
-				return fmt.Errorf("failed to fetch ResourceClaim %s referenced by pod %s: %+v", claimName, pod.Name, err)
+				return fmt.Errorf("failed to fetch ResourceClaim %s referenced by pod %s: %w", claimName, pod.Name, err)
 			}
 
 			// Check if pod is in the ReservedFor for the claim
 			if !resourceclaim.IsReservedForPod(pod, resourceClaim) {
-				return fmt.Errorf("pod %s(%s) is not allowed to use resource claim %s(%s)", pod.Name, pod.UID, podResourceClaim.Name, resourceClaim.UID)
+				return fmt.Errorf("pod %s(%s) is not allowed to use resource claim %s(%s)",
+					pod.Name, pod.UID, podResourceClaim.Name, resourceClaim.UID)
 			}
 
 			// Call NodePrepareResource RPC
 			driverName := resourceClaim.Status.DriverName
+
 			client, err := dra.NewDRAPluginClient(driverName)
 			if err != nil || client == nil {
-				return fmt.Errorf("failed to get DRA Plugin client for plugin name %s, err=%+v", driverName, err)
+				return fmt.Errorf("failed to get DRA Plugin client for plugin name %s, err=%w", driverName, err)
 			}
 
-			response, err := client.NodePrepareResource(context.Background(), resourceClaim.Namespace, resourceClaim.UID, resourceClaim.Name, resourceClaim.Status.Allocation.ResourceHandle)
+			response, err := client.NodePrepareResource(
+				context.Background(),
+				resourceClaim.Namespace,
+				resourceClaim.UID,
+				resourceClaim.Name,
+				resourceClaim.Status.Allocation.ResourceHandle)
 			if err != nil {
-				return fmt.Errorf("NodePrepareResource failed, claim UID: %s, claim name: %s, resource handle: %s, err: %+v", resourceClaim.UID, resourceClaim.Name, resourceClaim.Status.Allocation.ResourceHandle, err)
+				return fmt.Errorf("NodePrepareResource failed, claim UID: %s, claim name: %s, resource handle: %s, err: %w",
+					resourceClaim.UID, resourceClaim.Name, resourceClaim.Status.Allocation.ResourceHandle, err)
 			}
+
 			klog.V(3).InfoS("NodePrepareResource succeeded", "response", response)
 
 			annotations, err := generateCDIAnnotation(resourceClaim.UID, driverName, response.CdiDevice)
 			if err != nil {
-				return fmt.Errorf("failed to generate container annotations, err: %+v", err)
+				return fmt.Errorf("failed to generate container annotations, err: %w", err)
 			}
 
 			// Cache prepared resource
@@ -134,7 +156,11 @@ func (m *ManagerImpl) prepareContainerResources(pod *v1.Pod, container *v1.Conta
 					annotations: annotations,
 				})
 			if err != nil {
-				return fmt.Errorf("failed to cache prepared resource, claim: %s(%s), err: %+v", resourceClaim.Name, resourceClaim.UID, err)
+				return fmt.Errorf(
+					"failed to cache prepared resource, claim: %s(%s), err: %w",
+					resourceClaim.Name,
+					resourceClaim.UID,
+					err)
 			}
 		}
 	}
@@ -147,21 +173,27 @@ func (m *ManagerImpl) PrepareResources(pod *v1.Pod, container *v1.Container) (*D
 	if err := m.prepareContainerResources(pod, container); err != nil {
 		return nil, err
 	}
+
 	annotations := []kubecontainer.Annotation{}
+
 	for _, podResourceClaim := range pod.Spec.ResourceClaims {
 		claimName := resourceclaim.Name(pod, &podResourceClaim)
+
 		for _, claim := range container.Resources.Claims {
 			if podResourceClaim.Name != claim {
 				continue
 			}
+
 			resource := m.resources.get(claimName, pod.Namespace)
 			if resource == nil {
-				return nil, fmt.Errorf(fmt.Sprintf("unable to get resource for namespace: %s, claim: %s", pod.Namespace, claimName))
+				return nil, fmt.Errorf("unable to get resource for namespace: %s, claim: %s", pod.Namespace, claimName)
 			}
+
 			klog.V(3).InfoS("add resource annotations", "claim", claimName, "annotations", resource.annotations)
 			annotations = append(annotations, resource.annotations...)
 		}
 	}
+
 	return &DRAContainerInfo{Annotations: annotations}, nil
 }
 
@@ -172,6 +204,7 @@ func (m *ManagerImpl) UnprepareResources(pod *v1.Pod) error {
 	// Call NodeUnprepareResource RPC for every resource claim referenced by the pod
 	for _, podResourceClaim := range pod.Spec.ResourceClaims {
 		claimName := resourceclaim.Name(pod, &podResourceClaim)
+
 		resource := m.resources.get(claimName, pod.Namespace)
 		if resource == nil {
 			return fmt.Errorf("failed to get resource for namespace %s, claim %s", pod.Namespace, claimName)
@@ -194,12 +227,24 @@ func (m *ManagerImpl) UnprepareResources(pod *v1.Pod) error {
 		// Call NodeUnprepareResource only for the latest pod that refers the claim
 		client, err := dra.NewDRAPluginClient(resource.driverName)
 		if err != nil || client == nil {
-			return fmt.Errorf("failed to get DRA Plugin client for plugin name %s, err=%+v", resource.driverName, err)
+			return fmt.Errorf("failed to get DRA Plugin client for plugin name %s, err=%w", resource.driverName, err)
 		}
-		response, err := client.NodeUnprepareResource(context.Background(), resource.namespace, resource.claimUID, resource.claimName, resource.cdiDevice)
+
+		response, err := client.NodeUnprepareResource(
+			context.Background(),
+			resource.namespace,
+			resource.claimUID,
+			resource.claimName,
+			resource.cdiDevice)
 		if err != nil {
-			return fmt.Errorf("NodeUnprepareResource failed, pod: %s, claim UID: %s, claim name: %s, CDI devices: %s, err: %+v", pod.Name, resource.claimUID, resource.claimName, resource.cdiDevice, err)
+			return fmt.Errorf(
+				"NodeUnprepareResource failed, pod: %s, claim UID: %s, claim name: %s, CDI devices: %s, err: %w",
+				pod.Name,
+				resource.claimUID,
+				resource.claimName,
+				resource.cdiDevice, err)
 		}
+
 		klog.V(3).InfoS("NodeUnprepareResource succeeded", "response", response)
 		// delete resource from the cache
 		m.resources.delete(resource.claimName, pod.Namespace)

--- a/pkg/kubelet/cm/dra/plugin/client.go
+++ b/pkg/kubelet/cm/dra/plugin/client.go
@@ -51,10 +51,10 @@ type DRAClient interface {
 	) (*drapbv1.NodeUnprepareResourceResponse, error)
 }
 
-// Strongly typed address
+// Strongly typed address.
 type draAddr string
 
-// draPluginClient encapsulates all dra plugin methods
+// draPluginClient encapsulates all dra plugin methods.
 type draPluginClient struct {
 	pluginName          string
 	addr                draAddr
@@ -79,7 +79,7 @@ func (err *UncertainProgressError) Error() string {
 	return err.msg
 }
 
-// NewUncertainProgressError creates an instance of UncertainProgressError type
+// NewUncertainProgressError creates an instance of UncertainProgressError type.
 func NewUncertainProgressError(msg string) *UncertainProgressError {
 	return &UncertainProgressError{msg: msg}
 }
@@ -91,13 +91,13 @@ func NewUncertainProgressError(msg string) *UncertainProgressError {
 // newCsiDriverClient.
 func newV1NodeClient(addr draAddr) (nodeClient drapbv1.NodeClient, closer io.Closer, err error) {
 	var conn *grpc.ClientConn
+
 	conn, err = newGrpcConn(addr)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	nodeClient = drapbv1.NewNodeClient(conn)
-	return nodeClient, conn, nil
+	return drapbv1.NewNodeClient(conn), conn, nil
 }
 
 func NewDRAPluginClient(pluginName string) (DRAClient, error) {
@@ -110,11 +110,10 @@ func NewDRAPluginClient(pluginName string) (DRAClient, error) {
 		return nil, fmt.Errorf("plugin name %s not found in the list of registered DRA plugins", pluginName)
 	}
 
-	nodeV1ClientCreator := newV1NodeClient
 	return &draPluginClient{
 		pluginName:          pluginName,
 		addr:                draAddr(existingDriver.endpoint),
-		nodeV1ClientCreator: nodeV1ClientCreator,
+		nodeV1ClientCreator: newV1NodeClient,
 	}, nil
 }
 
@@ -145,7 +144,7 @@ func (r *draPluginClient) NodePrepareResource(
 	req := &drapbv1.NodePrepareResourceRequest{
 		Namespace:      namespace,
 		ClaimUid:       string(claimUID),
-		ClaimName:      string(claimName),
+		ClaimName:      claimName,
 		ResourceHandle: resourceHandle,
 	}
 
@@ -153,7 +152,8 @@ func (r *draPluginClient) NodePrepareResource(
 	if err != nil && !isFinalError(err) {
 		return nil, NewUncertainProgressError(err.Error())
 	}
-	return response, err
+
+	return response, fmt.Errorf("resource preparation failed: %w", err)
 }
 
 func (r *draPluginClient) NodeUnprepareResource(
@@ -169,6 +169,7 @@ func (r *draPluginClient) NodeUnprepareResource(
 		"claim UID", claimUID,
 		"claim name", claimName,
 		"cdi devices", cdiDevices)
+
 	if r.nodeV1ClientCreator == nil {
 		return nil, errors.New("nodeV1ClientCreate is nil")
 	}
@@ -182,7 +183,7 @@ func (r *draPluginClient) NodeUnprepareResource(
 	req := &drapbv1.NodeUnprepareResourceRequest{
 		Namespace: namespace,
 		ClaimUid:  string(claimUID),
-		ClaimName: string(claimName),
+		ClaimName: claimName,
 		CdiDevice: cdiDevices,
 	}
 
@@ -191,7 +192,7 @@ func (r *draPluginClient) NodeUnprepareResource(
 		return nil, NewUncertainProgressError(err.Error())
 	}
 
-	return response, err
+	return response, fmt.Errorf("resource un-preparation failed: %w", err)
 }
 
 func newGrpcConn(addr draAddr) (*grpc.ClientConn, error) {
@@ -208,14 +209,15 @@ func newGrpcConn(addr draAddr) (*grpc.ClientConn, error) {
 }
 
 func isFinalError(err error) bool {
-	st, ok := status.FromError(err)
+	stat, ok := status.FromError(err)
 	if !ok {
 		// This is not gRPC error. The operation must have failed before gRPC
 		// method was called, otherwise we would get gRPC error.
 		// We don't know if any previous volume operation is in progress, be on the safe side.
 		return false
 	}
-	switch st.Code() {
+
+	switch stat.Code() {
 	case codes.Canceled, // gRPC: Client Application cancelled the request
 		codes.DeadlineExceeded,  // gRPC: Timeout
 		codes.Unavailable,       // gRPC: Server shutting down, TCP connection broken - previous volume operation may be still in progress.

--- a/pkg/kubelet/cm/dra/plugin/plugin.go
+++ b/pkg/kubelet/cm/dra/plugin/plugin.go
@@ -26,21 +26,20 @@ import (
 )
 
 const (
-	// DRAPluginName is the name of the in-tree DRA Plugin
+	// DRAPluginName is the name of the in-tree DRA Plugin.
 	DRAPluginName = "kubernetes.io/dra"
 )
 
-// draPlugins map keep track of all registered DRA plugins on the node and their
-// corresponding sockets
+// draPlugins map keeps track of all registered DRA plugins on the node
+// and their corresponding sockets.
 var draPlugins = &PluginsStore{}
 
 // RegistrationHandler is the handler which is fed to the pluginwatcher API.
-type RegistrationHandler struct {
-}
+type RegistrationHandler struct{}
 
 var PluginHandler = &RegistrationHandler{}
 
-// RegisterPlugin is called when a plugin can be registered
+// RegisterPlugin is called when a plugin can be registered.
 func (h *RegistrationHandler) RegisterPlugin(pluginName string, endpoint string, versions []string) error {
 	klog.InfoS("Register new DRA plugin", "name", pluginName, "endpoint", endpoint)
 
@@ -59,41 +58,42 @@ func (h *RegistrationHandler) RegisterPlugin(pluginName string, endpoint string,
 	return nil
 }
 
-// Return the highest supported version
+// Return the highest supported version.
 func highestSupportedVersion(versions []string) (*utilversion.Version, error) {
 	if len(versions) == 0 {
 		return nil, errors.New(log("DRA driver reporting empty array for supported versions"))
 	}
 
 	var highestSupportedVersion *utilversion.Version
+
 	var theErr error
+
 	for i := len(versions) - 1; i >= 0; i-- {
 		currentHighestVer, err := utilversion.ParseGeneric(versions[i])
 		if err != nil {
 			theErr = err
+
 			continue
 		}
-		if currentHighestVer.Major() > 1 {
-			// CSI currently only has version 0.x and 1.x (see https://github.com/container-storage-interface/spec/releases).
-			// Therefore any driver claiming version 2.x+ is ignored as an unsupported versions.
-			// Future 1.x versions of CSI are supposed to be backwards compatible so this version of Kubernetes will work with any 1.x driver
-			// (or 0.x), but it may not work with 2.x drivers (because 2.x does not have to be backwards compatible with 1.x).
+
+		if currentHighestVer.Major() > 0 {
+			// DRA currently only has version 0.x
 			continue
 		}
+
 		if highestSupportedVersion == nil || highestSupportedVersion.LessThan(currentHighestVer) {
 			highestSupportedVersion = currentHighestVer
 		}
 	}
 
 	if highestSupportedVersion == nil {
-		return nil, fmt.Errorf("could not find a highest supported version from versions (%v) reported by this driver: %v", versions, theErr)
+		return nil, fmt.Errorf("could not find a highest supported version from versions (%v) reported by this driver: %w", versions, theErr)
 	}
 
-	if highestSupportedVersion.Major() != 1 {
-		// CSI v0.x is no longer supported as of Kubernetes v1.17 in
-		// accordance with deprecation policy set out in Kubernetes v1.13
-		return nil, fmt.Errorf("highest supported version reported by driver is %v, must be v1.x", highestSupportedVersion)
+	if highestSupportedVersion.Major() != 0 {
+		return nil, fmt.Errorf("highest supported version reported by driver is %v, must be v0.x", highestSupportedVersion)
 	}
+
 	return highestSupportedVersion, nil
 }
 
@@ -118,18 +118,15 @@ func (h *RegistrationHandler) validateVersions(callerName, pluginName string, en
 	return newDriverHighestVersion, nil
 }
 
-func unregisterPlugin(pluginName string) error {
+func unregisterPlugin(pluginName string) {
 	draPlugins.Delete(pluginName)
-	return nil
 }
 
-// DeRegisterPlugin is called when a plugin removed its socket, signaling
-// it is no longer available
+// DeRegisterPlugin is called when a plugin has removed its socket,
+// signaling it is no longer available.
 func (h *RegistrationHandler) DeRegisterPlugin(pluginName string) {
 	klog.InfoS("DeRegister DRA plugin", "name", pluginName)
-	if err := unregisterPlugin(pluginName); err != nil {
-		klog.ErrorS(err, "DeRegisterPlugin failed")
-	}
+	unregisterPlugin(pluginName)
 }
 
 // ValidatePlugin is called by kubelet's plugin watcher upon detection
@@ -139,13 +136,13 @@ func (h *RegistrationHandler) ValidatePlugin(pluginName string, endpoint string,
 
 	_, err := h.validateVersions("ValidatePlugin", pluginName, endpoint, versions)
 	if err != nil {
-		return fmt.Errorf("validation failed for DRA plugin %s at endpoint %s: %v", pluginName, endpoint, err)
+		return fmt.Errorf("validation failed for DRA plugin %s at endpoint %s: %w", pluginName, endpoint, err)
 	}
 
 	return err
 }
 
-// log prepends log string with `kubernetes.io/dra`
+// log prepends log string with `kubernetes.io/dra`.
 func log(msg string, parts ...interface{}) string {
 	return fmt.Sprintf(fmt.Sprintf("%s: %s", DRAPluginName, msg), parts...)
 }

--- a/pkg/kubelet/cm/dra/plugin/plugins_store.go
+++ b/pkg/kubelet/cm/dra/plugin/plugins_store.go
@@ -22,14 +22,14 @@ import (
 	utilversion "k8s.io/apimachinery/pkg/util/version"
 )
 
-// Plugin is a description of a DRA Plugin, defined by an enpoint and the
-// highest DRA version supported
+// Plugin is a description of a DRA Plugin, defined by an endpoint
+// and the highest DRA version supported.
 type Plugin struct {
 	endpoint                string
 	highestSupportedVersion *utilversion.Version
 }
 
-// PluginsStore holds a list of DRA Plugins
+// PluginsStore holds a list of DRA Plugins.
 type PluginsStore struct {
 	store map[string]*Plugin
 	sync.RWMutex

--- a/pkg/kubelet/cm/dra/resources.go
+++ b/pkg/kubelet/cm/dra/resources.go
@@ -26,7 +26,7 @@ import (
 )
 
 // resource contains resource attributes required
-// to prepare and unprepare the resource
+// to prepare and unprepare the resource.
 type resource struct {
 	sync.Mutex
 
@@ -75,13 +75,13 @@ func (res *resource) deletePodUID(podUID types.UID) {
 	res.podUIDs.Delete(string(podUID))
 }
 
-// claimedResources is cache of processed resources keyed by namespace + claim name
+// claimedResources is a cache of processed resources keyed by namespace + claim name.
 type claimedResources struct {
 	sync.RWMutex
 	resources map[string]*resource
 }
 
-// newClaimedResources is a function that returns object of podResources
+// newClaimedResources is a function that returns object of podResources.
 func newClaimedResources() *claimedResources {
 	return &claimedResources{
 		resources: make(map[string]*resource),
@@ -96,7 +96,9 @@ func (cres *claimedResources) add(claim, namespace string, res *resource) error 
 	if _, ok := cres.resources[key]; ok {
 		return fmt.Errorf("claim %s, namespace %s already cached", claim, namespace)
 	}
+
 	cres.resources[claim+namespace] = res
+
 	return nil
 }
 


### PR DESCRIPTION
Fixed some of the numerous `golangci-lint` findings to make the code more readable.